### PR TITLE
feat: support `overrides` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,22 @@ pluginNodePolyfill({
 });
 ```
 
+### overrides
+
+Override the default polyfills for specific modules.
+
+- **Type:** `Record<string, string>`
+- **Default:** `{}`
+
+```ts
+pluginNodePolyfill({
+  overrides: {
+    fs: 'memfs',
+  },
+});
+```
+
+
 ## License
 
 [MIT](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -209,7 +209,3 @@ pluginNodePolyfill({
 ## License
 
 [MIT](./LICENSE).
-
-## License
-
-[MIT](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Add plugin to your `rsbuild.config.ts`:
 
 ```ts
 // rsbuild.config.ts
-import { pluginNodePolyfill } from "@rsbuild/plugin-node-polyfill";
+import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill'
 
 export default {
   plugins: [pluginNodePolyfill()],
-};
+}
 ```
 
 ## Node Polyfills
@@ -47,7 +47,7 @@ When you use the above global variables in your code, the corresponding polyfill
 For instance, the following code would inject the `Buffer` polyfill:
 
 ```ts
-const bufferData = Buffer.from("abc");
+const bufferData = Buffer.from('abc')
 ```
 
 You can disable this behavior through the `globals` option of the plugin:
@@ -58,7 +58,7 @@ pluginNodePolyfill({
     Buffer: false,
     process: false,
   },
-});
+})
 ```
 
 ### Modules
@@ -95,9 +95,9 @@ pluginNodePolyfill({
 When the above module is referenced in code via import / require syntax, the corresponding polyfill will be injected.
 
 ```ts
-import { Buffer } from "buffer";
+import { Buffer } from 'buffer'
 
-const bufferData = Buffer.from("abc");
+const bufferData = Buffer.from('abc')
 ```
 
 ### Fallbacks
@@ -116,9 +116,9 @@ const bufferData = Buffer.from("abc");
 Currently there is no polyfill for the above modules on the browser side, so when you import the above modules, it will automatically fallback to an empty object.
 
 ```ts
-import fs from "fs";
+import fs from 'fs'
 
-console.log(fs); // -> {}
+console.log(fs) // -> {}
 ```
 
 ## Options
@@ -131,9 +131,9 @@ Used to specify whether to inject polyfills for global variables.
 
 ```ts
 type Globals = {
-  process?: boolean;
-  Buffer?: boolean;
-};
+  process?: boolean
+  Buffer?: boolean
+}
 ```
 
 - **Default:**
@@ -142,7 +142,7 @@ type Globals = {
 const defaultGlobals = {
   Buffer: true,
   process: true,
-};
+}
 ```
 
 ### protocolImports
@@ -157,7 +157,7 @@ For example, if you disable `protocolImports`, modules such as `node:path`, `nod
 ```ts
 pluginNodePolyfill({
   protocolImports: false,
-});
+})
 ```
 
 ### include
@@ -169,8 +169,8 @@ Specify an array of modules for which polyfills should be injected. If this opti
 
 ```ts
 pluginNodePolyfill({
-  include: ["buffer", "crypto"], // Only "buffer" and "crypto" modules will be polyfilled.
-});
+  include: ['buffer', 'crypto'], // Only "buffer" and "crypto" modules will be polyfilled.
+})
 ```
 
 ### exclude
@@ -182,8 +182,8 @@ Specify an array of modules for which polyfills should not be injected from the 
 
 ```ts
 pluginNodePolyfill({
-  exclude: ["http", "https"], // All modules except "http" and "https" will be polyfilled.
-});
+  exclude: ['http', 'https'], // All modules except "http" and "https" will be polyfilled.
+})
 ```
 
 ### overrides
@@ -198,9 +198,17 @@ pluginNodePolyfill({
   overrides: {
     fs: 'memfs',
   },
-});
+})
 ```
 
+## Exported variables
+
+- `builtinMappingResolved`: A map of Node.js builtin modules to their resolved corresponding polyfills modules.
+- `resolvedPolyfillToModules`: A map of resolved polyfill modules to the polyfill modules before resolving.
+
+## License
+
+[MIT](./LICENSE).
 
 ## License
 

--- a/src/libs.ts
+++ b/src/libs.ts
@@ -2,51 +2,53 @@ import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 
-export const assert: string = require.resolve('assert/');
-export const buffer: string = require.resolve('buffer/');
-export const child_process = null;
-export const cluster = null;
-export const console: string = require.resolve('console-browserify');
-export const constants: string = require.resolve('constants-browserify');
-export const crypto: string = require.resolve('crypto-browserify');
-export const dgram = null;
-export const dns = null;
-export const domain: string = require.resolve('domain-browser');
-export const events: string = require.resolve('events/');
-export const fs = null;
-export const http: string = require.resolve('stream-http');
-export const https: string = require.resolve('https-browserify');
-export const module = null;
-export const net = null;
-export const os: string = require.resolve('os-browserify/browser.js');
-export const path: string = require.resolve('path-browserify');
-export const punycode: string = require.resolve('punycode/');
-export const process: string = require.resolve('process/browser.js');
-export const querystring: string = require.resolve('querystring-es3/');
-export const readline = null;
-export const repl = null;
-export const stream: string = require.resolve('stream-browserify');
-export const _stream_duplex: string = require.resolve(
-	'readable-stream/lib/_stream_duplex.js',
+export const builtinMappingResolved = {
+	assert: require.resolve('assert/'),
+	buffer: require.resolve('buffer/'),
+	child_process: null,
+	cluster: null,
+	console: require.resolve('console-browserify'),
+	constants: require.resolve('constants-browserify'),
+	crypto: require.resolve('crypto-browserify'),
+	dgram: null,
+	dns: null,
+	domain: require.resolve('domain-browser'),
+	events: require.resolve('events/'),
+	fs: null,
+	http: require.resolve('stream-http'),
+	https: require.resolve('https-browserify'),
+	module: null,
+	net: null,
+	os: require.resolve('os-browserify/browser.js'),
+	path: require.resolve('path-browserify'),
+	punycode: require.resolve('punycode/'),
+	process: require.resolve('process/browser.js'),
+	querystring: require.resolve('querystring-es3/'),
+	readline: null,
+	repl: null,
+	stream: require.resolve('stream-browserify'),
+	_stream_duplex: require.resolve('readable-stream/lib/_stream_duplex.js'),
+	_stream_passthrough: require.resolve(
+		'readable-stream/lib/_stream_passthrough.js',
+	),
+	_stream_readable: require.resolve('readable-stream/lib/_stream_readable.js'),
+	_stream_transform: require.resolve(
+		'readable-stream/lib/_stream_transform.js',
+	),
+	_stream_writable: require.resolve('readable-stream/lib/_stream_writable.js'),
+	string_decoder: require.resolve('string_decoder/'),
+	sys: require.resolve('util/util.js'),
+	timers: require.resolve('timers-browserify'),
+	tls: null,
+	tty: require.resolve('tty-browserify'),
+	url: require.resolve('url/'),
+	util: require.resolve('util/util.js'),
+	vm: require.resolve('vm-browserify'),
+	zlib: require.resolve('browserify-zlib'),
+} as const;
+
+export const resolvedPolyfillToModules = Object.fromEntries(
+	Object.entries(builtinMappingResolved)
+		.filter(([key]) => key !== null)
+		.map(([key, value]) => [value, key]),
 );
-export const _stream_passthrough: string = require.resolve(
-	'readable-stream/lib/_stream_passthrough.js',
-);
-export const _stream_readable: string = require.resolve(
-	'readable-stream/lib/_stream_readable.js',
-);
-export const _stream_transform: string = require.resolve(
-	'readable-stream/lib/_stream_transform.js',
-);
-export const _stream_writable: string = require.resolve(
-	'readable-stream/lib/_stream_writable.js',
-);
-export const string_decoder: string = require.resolve('string_decoder/');
-export const sys: string = require.resolve('util/util.js');
-export const timers: string = require.resolve('timers-browserify');
-export const tls = null;
-export const tty: string = require.resolve('tty-browserify');
-export const url: string = require.resolve('url/');
-export const util: string = require.resolve('util/util.js');
-export const vm: string = require.resolve('vm-browserify');
-export const zlib: string = require.resolve('browserify-zlib');

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,5 +1,15 @@
 import { expect, test } from 'vitest';
-import { getResolveFallback } from '../../src/index';
+import {
+	builtinMappingResolved,
+	getResolveFallback,
+	resolvePolyfill,
+} from '../../src/index';
+
+test('resolvePolyfill', () => {
+	expect(resolvePolyfill('fs', { fs: 'memfs' })).toBe('memfs');
+	expect(resolvePolyfill('fs')).toBe(null);
+	expect(resolvePolyfill('buffer')).toBe(builtinMappingResolved.buffer);
+});
 
 test('getResolveFallback', () => {
 	const defaultFallback = getResolveFallback({});
@@ -149,6 +159,12 @@ test('getResolveFallback', () => {
 	expect(Object.keys(getResolveFallback({ include: ['fs'] }))).toStrictEqual([
 		'fs',
 	]);
+
+	const overrides = getResolveFallback({ overrides: { fs: 'memfs' } });
+	expect(overrides.fs).toStrictEqual('memfs');
+	expect({ ...overrides, fs: defaultFallback.fs }).toStrictEqual(
+		defaultFallback,
+	);
 
 	expect(() =>
 		getResolveFallback({ include: ['fs'], exclude: ['path'] }),


### PR DESCRIPTION
Add `overrides` and exports `resolvedPolyfillToModules` map.

- `overrides` to align with https://github.com/davidmyersdev/vite-plugin-node-polyfills
- `resolvedPolyfillToModules` for Rslib in bundleless mode, usage example


```diff
export default defineConfig({
  lib: [
    generateBundleEsmConfig({
      bundle: false,
      source: {
        entry: {
          index: ['./src/**'],
        },
      },
      output: {
+        externals: Object.keys(resolvedPolyfillToModules).reduce(
+          (acc, key) => {
+            acc[key] = `node-commonjs ${key}`;
+            return acc;
+          },
+          {} as Record<string, string>,
        ),
        distPath: {
          root: './dist/esm/bundleless',
        },
      },
    }),
  ],
+  plugins: [pluginNodePolyfill()],
  source: {
    entry: {
      index: './src/index.ts',
    },
  },
});
```