### PR TITLE
feat: add polyfillServer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ pluginNodePolyfill({
 })
 ```
 
+### polyfillServer
+
+Polyfill the server-side code as well.
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+```ts
+pluginNodePolyfill({
+  polyfillServer: true,
+})
+```
+
 ## Exported variables
 
 - `builtinMappingResolved`: A map of Node.js builtin modules to their resolved corresponding polyfills modules.

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,11 @@ export type PluginNodePolyfillOptions = {
 	 * @default undefined
 	 */
 	overrides?: Record<string, string | false>;
+	/**
+	 * Polyfill the server-side code as well.
+	 * @default false
+	 */
+	polyfillServer?: boolean;
 };
 
 export const resolvePolyfill = (
@@ -107,7 +112,13 @@ export const PLUGIN_NODE_POLYFILL_NAME = 'rsbuild:node-polyfill';
 export function pluginNodePolyfill(
 	options: PluginNodePolyfillOptions = {},
 ): RsbuildPlugin {
-	const { protocolImports = true, include, exclude, overrides } = options;
+	const {
+		protocolImports = true,
+		include,
+		exclude,
+		overrides,
+		polyfillServer = false,
+	} = options;
 
 	return {
 		name: PLUGIN_NODE_POLYFILL_NAME,
@@ -115,7 +126,7 @@ export function pluginNodePolyfill(
 		setup(api) {
 			api.modifyBundlerChain(async (chain, { isServer, bundler }) => {
 				// The server bundle does not require node polyfill
-				if (isServer) {
+				if (isServer && !polyfillServer) {
 					return;
 				}
 


### PR DESCRIPTION
In some environments, rsbuild should behave exactly like it does with the " `target: 'node'` option, except those environments don't provide nodejs modules and require a polyfill. In particular goja and inherently sobek, which is used by the k6 framework.

Unfortunately the node target sets `isServer` to `true` and this plugin disables itself which to be fair, is reasonable.
However an option to explicitly enable that behavior is infinitely useful in such situations.

If you have any questions regarding the implementation, please mention me.
Best regards Blackfur