### PR TITLE
chore: rename `polyfillServer` option to `force`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Add plugin to your `rsbuild.config.ts`:
 
 ```ts
 // rsbuild.config.ts
-import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill'
+import { pluginNodePolyfill } from "@rsbuild/plugin-node-polyfill";
 
 export default {
   plugins: [pluginNodePolyfill()],
-}
+};
 ```
 
 ## Node Polyfills
@@ -47,7 +47,7 @@ When you use the above global variables in your code, the corresponding polyfill
 For instance, the following code would inject the `Buffer` polyfill:
 
 ```ts
-const bufferData = Buffer.from('abc')
+const bufferData = Buffer.from("abc");
 ```
 
 You can disable this behavior through the `globals` option of the plugin:
@@ -58,7 +58,7 @@ pluginNodePolyfill({
     Buffer: false,
     process: false,
   },
-})
+});
 ```
 
 ### Modules
@@ -95,9 +95,9 @@ pluginNodePolyfill({
 When the above module is referenced in code via import / require syntax, the corresponding polyfill will be injected.
 
 ```ts
-import { Buffer } from 'buffer'
+import { Buffer } from "buffer";
 
-const bufferData = Buffer.from('abc')
+const bufferData = Buffer.from("abc");
 ```
 
 ### Fallbacks
@@ -116,9 +116,9 @@ const bufferData = Buffer.from('abc')
 Currently there is no polyfill for the above modules on the browser side, so when you import the above modules, it will automatically fallback to an empty object.
 
 ```ts
-import fs from 'fs'
+import fs from "fs";
 
-console.log(fs) // -> {}
+console.log(fs); // -> {}
 ```
 
 ## Options
@@ -131,9 +131,9 @@ Used to specify whether to inject polyfills for global variables.
 
 ```ts
 type Globals = {
-  process?: boolean
-  Buffer?: boolean
-}
+  process?: boolean;
+  Buffer?: boolean;
+};
 ```
 
 - **Default:**
@@ -142,7 +142,7 @@ type Globals = {
 const defaultGlobals = {
   Buffer: true,
   process: true,
-}
+};
 ```
 
 ### protocolImports
@@ -157,7 +157,7 @@ For example, if you disable `protocolImports`, modules such as `node:path`, `nod
 ```ts
 pluginNodePolyfill({
   protocolImports: false,
-})
+});
 ```
 
 ### include
@@ -169,8 +169,8 @@ Specify an array of modules for which polyfills should be injected. If this opti
 
 ```ts
 pluginNodePolyfill({
-  include: ['buffer', 'crypto'], // Only "buffer" and "crypto" modules will be polyfilled.
-})
+  include: ["buffer", "crypto"], // Only "buffer" and "crypto" modules will be polyfilled.
+});
 ```
 
 ### exclude
@@ -182,8 +182,8 @@ Specify an array of modules for which polyfills should not be injected from the 
 
 ```ts
 pluginNodePolyfill({
-  exclude: ['http', 'https'], // All modules except "http" and "https" will be polyfilled.
-})
+  exclude: ["http", "https"], // All modules except "http" and "https" will be polyfilled.
+});
 ```
 
 ### overrides
@@ -196,22 +196,22 @@ Override the default polyfills for specific modules.
 ```ts
 pluginNodePolyfill({
   overrides: {
-    fs: 'memfs',
+    fs: "memfs",
   },
-})
+});
 ```
 
-### polyfillServer
+### force
 
-Polyfill the server-side code as well.
+By default, the plugin only polyfills the browser-side code. If you want to polyfill the server-side code as well (when `output.target` is `node`), you can set the `force` option to `true`.
 
 - **Type:** `boolean`
 - **Default:** `false`
 
 ```ts
 pluginNodePolyfill({
-  polyfillServer: true,
-})
+  force: true,
+});
 ```
 
 ## Exported variables

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,10 +41,12 @@ export type PluginNodePolyfillOptions = {
 	 */
 	overrides?: Record<string, string | false>;
 	/**
-	 * Polyfill the server-side code as well.
+	 * By default, the plugin only polyfills the browser-side code.
+	 * If you want to polyfill the server-side code as well (when `output.target` is `node`),
+	 * you can set the `force` option to `true`.
 	 * @default false
 	 */
-	polyfillServer?: boolean;
+	force?: boolean;
 };
 
 export const resolvePolyfill = (
@@ -117,7 +119,7 @@ export function pluginNodePolyfill(
 		include,
 		exclude,
 		overrides,
-		polyfillServer = false,
+		force = false,
 	} = options;
 
 	return {
@@ -126,7 +128,7 @@ export function pluginNodePolyfill(
 		setup(api) {
 			api.modifyBundlerChain(async (chain, { isServer, bundler }) => {
 				// The server bundle does not require node polyfill
-				if (isServer && !polyfillServer) {
+				if (isServer && !force) {
 					return;
 				}
 


### PR DESCRIPTION
Renamed `polyfillServer` to `force` as it better represents the option's purpose - to force polyfill injection regardless of the environment, not just for server builds.

This is more generic and follows common API design patterns where force indicates overriding default behavior.

Related: https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill/pull/18