### PR TITLE
fix: polyfill global properties for Buffer and process

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-	testMatch: '*test/e2e/*.test.ts',
+	testMatch: '*test/e2e/**/*.test.ts',
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,9 +101,13 @@ export const getProvideGlobals = async (
 
 	if (globals?.Buffer !== false) {
 		result.Buffer = [resolvePolyfill('buffer', overrides) as string, 'Buffer'];
+		result['global.Buffer'] = result.Buffer;
+		result['globalThis.Buffer'] = result.Buffer;
 	}
 	if (globals?.process !== false) {
 		result.process = [resolvePolyfill('process', overrides) as string];
+		result['global.process'] = result.process;
+		result['globalThis.process'] = result.process;
 	}
 
 	return result;

--- a/test/e2e/basic/index.test.ts
+++ b/test/e2e/basic/index.test.ts
@@ -21,9 +21,6 @@ test('should add node-polyfill when add node-polyfill plugin', async ({
 	const test = page.locator('#test');
 	await expect(test).toHaveText('Hello Rsbuild!');
 
-	const testBuffer = page.locator('#test-buffer');
-	await expect(testBuffer).toHaveText('979899');
-
 	const testQueryString = page.locator('#test-querystring');
 	await expect(testQueryString).toHaveText('foo=bar');
 

--- a/test/e2e/basic/rsbuild.config.ts
+++ b/test/e2e/basic/rsbuild.config.ts
@@ -3,4 +3,7 @@ import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 
 export default defineConfig({
 	plugins: [pluginNodePolyfill()],
+	server: {
+		port: 3500,
+	},
 });

--- a/test/e2e/basic/src/index.js
+++ b/test/e2e/basic/src/index.js
@@ -2,15 +2,12 @@ import path from 'node:path';
 // biome-ignore lint: test non-import protocol
 import querystring from 'querystring';
 
-const bufferData = Buffer.from('abc');
-
 const qsRes = querystring.stringify({
 	foo: 'bar',
 });
 
 document.querySelector('#root').innerHTML = `
   <div>
-    <div id="test-buffer">${bufferData.join('')}</div>
     <div id="test-querystring">${qsRes}</div>
     <div id="test-path">${path.join('foo', 'bar')}</div>
     <div id="test">Hello Rsbuild!</div>

--- a/test/e2e/buffer/index.test.ts
+++ b/test/e2e/buffer/index.test.ts
@@ -1,0 +1,29 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { loadConfig } from '@rsbuild/core';
+import { createRsbuild } from '@rsbuild/core';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('should polyfill global Buffer as expected', async ({ page }) => {
+	const rsbuild = await createRsbuild({
+		cwd: __dirname,
+		rsbuildConfig: (await loadConfig({ cwd: __dirname })).content,
+	});
+
+	const { server, urls } = await rsbuild.startDevServer();
+
+	await page.goto(urls[0]);
+
+	const testBuffer1 = page.locator('#test-buffer1');
+	await expect(testBuffer1).toHaveText('979899');
+
+	const testBuffer2 = page.locator('#test-buffer2');
+	await expect(testBuffer2).toHaveText('979899');
+
+	const testBuffer3 = page.locator('#test-buffer3');
+	await expect(testBuffer3).toHaveText('979899');
+
+	await server.close();
+});

--- a/test/e2e/buffer/rsbuild.config.ts
+++ b/test/e2e/buffer/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
+
+export default defineConfig({
+	plugins: [pluginNodePolyfill()],
+	server: {
+		port: 4000,
+	},
+});

--- a/test/e2e/buffer/src/index.js
+++ b/test/e2e/buffer/src/index.js
@@ -1,0 +1,11 @@
+const bufferData1 = Buffer.from('abc');
+const bufferData2 = global.Buffer.from('abc');
+const bufferData3 = globalThis.Buffer.from('abc');
+
+document.querySelector('#root').innerHTML = `
+  <div>
+    <div id="test-buffer1">${bufferData1.join('')}</div>
+    <div id="test-buffer2">${bufferData2.join('')}</div>
+    <div id="test-buffer3">${bufferData3.join('')}</div>
+  </div>
+`;


### PR DESCRIPTION
Polyfill global properties for Buffer and process:

```js
global.Buffer.from('abc');
globalThis.Buffer.from('abc');

global.process;
globalThis.process;
```
