### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@rsbuild/plugin-node-polyfill",
   "version": "1.4.6",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-node-polyfill",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-node-polyfill#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-node-polyfill/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add the package homepage pointing to the repository README
- add the package bugs URL pointing to GitHub issues

## Validation
- `node -e "const p=require('./package.json'); if (p.homepage !== 'https://github.com/rstackjs/rsbuild-plugin-node-polyfill#readme') throw new Error('homepage mismatch'); if (!p.bugs || p.bugs.url !== 'https://github.com/rstackjs/rsbuild-plugin-node-polyfill/issues') throw new Error('bugs url mismatch'); console.log(JSON.stringify({name:p.name, homepage:p.homepage, bugs:p.bugs.url}, null, 2));"`
- `npm view @rsbuild/plugin-node-polyfill@latest name version repository.url homepage bugs --json`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`